### PR TITLE
Fix tree balancing logic. fixes #14

### DIFF
--- a/src/Data/PSQueue/Internal.hs
+++ b/src/Data/PSQueue/Internal.hs
@@ -466,19 +466,17 @@ omega = 4
 lbalance, rbalance ::
   Ord p => k -> p -> LTree k p -> k -> LTree k p -> LTree k p
 
-lbalance k p Start m r        = lloser        k p Start m r
-lbalance k p l m Start        = lloser        k p l m Start
 lbalance k p l m r
+  | size' r + size' l < 2     = lloser        k p l m r
   | size' r > omega * size' l = lbalanceLeft  k p l m r
   | size' l > omega * size' r = lbalanceRight k p l m r
-  | otherwise               = lloser        k p l m r
+  | otherwise                 = lloser        k p l m r
 
-rbalance k p Start m r        = rloser        k p Start m r
-rbalance k p l m Start        = rloser        k p l m Start
 rbalance k p l m r
+  | size' r + size' l < 2     = rloser        k p l m r
   | size' r > omega * size' l = rbalanceLeft  k p l m r
   | size' l > omega * size' r = rbalanceRight k p l m r
-  | otherwise               = rloser        k p l m r
+  | otherwise                 = rloser        k p l m r
 
 {-# INLINABLE lbalanceLeft #-}
 lbalanceLeft :: Ord p => k -> p -> LTree k p -> k -> LTree k p -> LTree k p


### PR DESCRIPTION
The tree balancing logic would never run on a node with a leaf directly below it, even when the other child is deeply nested. This appears to be the result of an attempt at optimizing the code in the original Hinze paper, but missing this case.

This patch reverts the balancing logic to what is described in the paper.

This fixes a test case that apparently no one noticed was failing.